### PR TITLE
Remove open system call for Darwin

### DIFF
--- a/lib/tors.rb
+++ b/lib/tors.rb
@@ -28,7 +28,22 @@ module TorS
     opts.on('-a', '--auto-download', 'Auto download best choice') do
       options[:auto] = true
     end
+
+    if RUBY_PLATFORM =~ /darwin/
+      opts.on('-o', '--open', 'Open torrent after downloading') do
+        options[:open] = true
+      end
+    end
+
   end.parse!
 
-  TorS::Search.new(options[:search], options[:provider] || 'katcr', options[:auto] || false, options[:directory] || Dir.pwd)
+  tors = TorS::Search.new(options[:provider] || 'katcr') do |ts|
+    ts.query        = options[:search]
+    ts.auto         = options[:auto] || false
+    ts.directory    = options[:directory] || Dir.pwd
+    ts.open_torrent = options[:open] || false
+  end
+
+  tors.run
+
 end

--- a/lib/tors/search.rb
+++ b/lib/tors/search.rb
@@ -120,7 +120,6 @@ module TorS
           puts '😵  There is an error! ' + e.message
         ensure
           puts '🥂  Downloaded!'
-          system 'open', target_file if RUBY_PLATFORM =~ /darwin/
         end
       end
     end

--- a/lib/tors/version.rb
+++ b/lib/tors/version.rb
@@ -1,3 +1,3 @@
 module TorS
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end


### PR DESCRIPTION
Automatically opening a torrent via system call is an intrusive
operation. Tors is a torrent search utility and it shouldn't assume that
the user has a torrent client installed. It should be up to the user
whether to open it or not.

Resolves #3