### PR TITLE
Refactor option parsing and class definition

### DIFF
--- a/lib/tors.rb
+++ b/lib/tors.rb
@@ -30,7 +30,7 @@ module TorS
       puts '- katcr'
       puts '- rarbg'
       puts '- thepiratebay'
-      puts '- zamunda'
+      puts '- zamunda (require authentication)'
       puts '- zooqle'
       abort
     end

--- a/lib/tors/search.rb
+++ b/lib/tors/search.rb
@@ -9,12 +9,17 @@ require 'colorize'
 
 module TorS
   class Search
-    attr_accessor :query, :from, :username, :password, :directory, :auto, :open_torrent
+    attr_accessor :from, :username, :password, :directory, :auto_download, :open_torrent
 
-    def initialize(from = 'katcr')
+    # Initialize class. Only query string is required and the rest of the attributes
+    # are assigned default values.
+    def initialize(query)
       raise "#{self.class} requires block to initialize" unless block_given?
+      yield self
 
-      @from = from
+      @query = query
+      @from ||= 'katcr'
+      @directory ||= Dir.pwd
 
       yaml = File.expand_path("../../../providers/#{from}.yml", __FILE__)
       if File.exist? yaml
@@ -22,8 +27,6 @@ module TorS
       else
         list_providers_and_exit
       end
-
-      yield self
     end
 
     def run
@@ -95,7 +98,7 @@ module TorS
       table = TTY::Table.new %i[# Category Title Size Seed Leech], @rows
       puts table.render(:unicode, padding: [0, 1, 0, 1])
 
-      if @auto
+      if @auto_download
         download @downloads.find { |v| v[:key] == 1 }
       else
         prompt

--- a/lib/tors/version.rb
+++ b/lib/tors/version.rb
@@ -1,3 +1,3 @@
 module TorS
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/tors.gemspec
+++ b/tors.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colorize', '~> 0.8.1'
   spec.add_dependency 'tty-table', '~> 0.8.0'
   spec.add_dependency 'tty-prompt', '~> 0.13.1'
+  spec.add_dependency 'slop', '~> 4.5.0'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
- Use slop library for option parsing. Accept variable arguments for search
  string and print usage when no argument is passed.
- Refactor class definition. Accept search string as a required parameter and
  set default values for other variables in the class.
- Check if username/password are provided when a provider that requires
  authentication is used.

Resolves: #7
Resolves: #8